### PR TITLE
update broken amazon product link to direct to an amazon search

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Generated .apk is available in Releases tab. In case you want to build from sour
 4. `scripts\build.bat`
 
 ## Hardware
-Running the app requires a OBD bluetooth connector plugged in the OBD-CAN connector of the car. ELM 327 is the model tested with this version of the app, it costs USD 10-15 in [Amazon] (https://www.amazon.com/Bluetooth-Scanner-Adapter-Diagnostic-Android/dp/B019SURWYO).
+Running the app requires a OBD bluetooth connector plugged in the OBD-CAN connector of the car. ELM 327 is the model tested with this version of the app, it costs USD 10-15 in [Amazon](https://www.amazon.com/s?k=bluetooth+obd+2+connector).
 
 ## Configuration
 1. Plug the OBD connector.


### PR DESCRIPTION
The link to Amazon listed on the README is to a product that is no longer sold via that link, so it leads to a 404 page. Additionally, there was a space between the brackets and the link which made it not display correctly. 

I removed the space to fix the link formatting, and changed the link itself to be for an Amazon search of "bluetooth obd 2 connector" rather than any specific product, so the link will remain active regardless of whether any specific product is removed. I wasn't sure what product used to exist there (I suspect one of the cheaper blue ones?), but I figured "bluetooth obd 2 connector" would get the job done. 